### PR TITLE
Fixing some typo in INLINE pragmas in V2.hs

### DIFF
--- a/src/Linear/V2.hs
+++ b/src/Linear/V2.hs
@@ -111,13 +111,13 @@ instance Traversable1 V2 where
 
 instance Apply V2 where
   V2 a b <.> V2 d e = V2 (a d) (b e)
-  {-@ INLINE (<.>) #-}
+  {-# INLINE (<.>) #-}
 
 instance Applicative V2 where
   pure a = V2 a a
   {-# INLINE pure #-}
   V2 a b <*> V2 d e = V2 (a d) (b e)
-  {-@ INLINE (<*>) #-}
+  {-# INLINE (<*>) #-}
 
 instance Hashable a => Hashable (V2 a) where
   hashWithSalt s (V2 a b) = s `hashWithSalt` a `hashWithSalt` b


### PR DESCRIPTION
Some inline directives were starting with {-@ instead of {-#
