### PR TITLE
Add TypeFamilies extension to Linear.Matrix

### DIFF
--- a/src/Linear/Matrix.hs
+++ b/src/Linear/Matrix.hs
@@ -1,5 +1,6 @@
 {-# LANGUAGE CPP #-}
 {-# LANGUAGE RankNTypes #-}
+{-# LANGUAGE TypeFamilies #-}
 #if defined(__GLASGOW_HASKELL__) && __GLASGOW_HASKELL__ >= 702
 {-# LANGUAGE Trustworthy #-}
 #endif


### PR DESCRIPTION
This fixes one of several build errors when compiling with GHC HEAD.

```
src/Linear/Matrix.hs:65:4:
    Illegal equational constraint Rep f ~ Rep f
    (Use GADTs or TypeFamilies to permit this)
    When checking that ‘o’ has the inferred type
      o :: forall (f1 :: * -> *) (f2 :: * -> *).
           (Representable f2, Representable f1, Rep f2 ~ Rep f,
            Rep f1 ~ Rep f) =>
           f2 b -> f1 t
    In an equation for ‘column’:
        column l f es
          = o <$> f i
          where
              go = l (Context id)
              i = tabulate $ \ e -> ipos $ go (index es e)
              o eb = tabulate $ \ e -> ipeek (index eb e) (go (index es e))
```
