### PR TITLE
Scale matrices.

### DIFF
--- a/src/Linear/Matrix.hs
+++ b/src/Linear/Matrix.hs
@@ -33,9 +33,6 @@ module Linear.Matrix
   , fromQuaternion
   , mkTransformation
   , mkTransformationMat
-  , scale2
-  , scale3
-  , scale4
   ) where
 
 import Control.Applicative
@@ -379,24 +376,3 @@ inv44 (V4 (V4 i00 i01 i02 i03)
                        (-i30 * s3 + i31 * s1 - i32 * s0)
                        (i20 * s3 - i21 * s1 + i22 * s0)))
 {-# INLINE inv44 #-}
-
--- | 2x2 scale matrix.
-scale2 :: (Num a) => V2 a -> M22 a
-scale2 (V2 x y) = V2 (V2 x 0) (V2 0 y)
-
--- | 3x3 scale matrix.
-scale3 :: (Num a) => V3 a -> M33 a
-scale3 (V3 x y z) =
-  V3
-    (V3 x 0 0)
-    (V3 0 y 0)
-    (V3 0 0 z)
-
--- | 4x4 scale matrix.
-scale4 :: (Num a) => V4 a -> M44 a
-scale4 (V4 x y z w) =
-  V4
-    (V4 x 0 0 0)
-    (V4 0 y 0 0)
-    (V4 0 0 z 0)
-    (V4 0 0 0 w)

--- a/src/Linear/Matrix.hs
+++ b/src/Linear/Matrix.hs
@@ -33,6 +33,9 @@ module Linear.Matrix
   , fromQuaternion
   , mkTransformation
   , mkTransformationMat
+  , scale2
+  , scale3
+  , scale4
   ) where
 
 import Control.Applicative
@@ -376,3 +379,24 @@ inv44 (V4 (V4 i00 i01 i02 i03)
                        (-i30 * s3 + i31 * s1 - i32 * s0)
                        (i20 * s3 - i21 * s1 + i22 * s0)))
 {-# INLINE inv44 #-}
+
+-- | 2x2 scale matrix.
+scale2 :: (Num a) => V2 a -> M22 a
+scale2 (V2 x y) = V2 (V2 x 0) (V2 0 y)
+
+-- | 3x3 scale matrix.
+scale3 :: (Num a) => V3 a -> M33 a
+scale3 (V3 x y z) =
+  V3
+    (V3 x 0 0)
+    (V3 0 y 0)
+    (V3 0 0 z)
+
+-- | 4x4 scale matrix.
+scale4 :: (Num a) => V4 a -> M44 a
+scale4 (V4 x y z w) =
+  V4
+    (V4 x 0 0 0)
+    (V4 0 y 0 0)
+    (V4 0 0 z 0)
+    (V4 0 0 0 w)

--- a/src/Linear/Vector.hs
+++ b/src/Linear/Vector.hs
@@ -28,7 +28,7 @@ module Linear.Vector
   , sumV
   , basis
   , basisFor
-  , kronecker
+  , scaled
   , outer
   , unit
   ) where
@@ -385,8 +385,8 @@ basisFor :: (Traversable t, Num a) => t b -> [t a]
 basisFor = choices . traverse (\_ -> SetOne 0 [1])
 
 -- | Produce a diagonal (scale) matrix from a vector.
-scale :: (Traversable t, Num a) => t a -> t (t a)
-scale v = fillFromList (choices $ traverse (\a -> SetOne 0 [a]) v) v
+scaled :: (Traversable t, Num a) => t a -> t (t a)
+scaled v = fillFromList (choices $ traverse (\a -> SetOne 0 [a]) v) v
 
 -- | Create a unit vector.
 --

--- a/src/Linear/Vector.hs
+++ b/src/Linear/Vector.hs
@@ -384,9 +384,9 @@ basis = basisFor (zero :: Additive v => v Int)
 basisFor :: (Traversable t, Num a) => t b -> [t a]
 basisFor = choices . traverse (\_ -> SetOne 0 [1])
 
--- | Produce a diagonal matrix from a vector.
-kronecker :: (Traversable t, Num a) => t a -> t (t a)
-kronecker v = fillFromList (choices $ traverse (\a -> SetOne 0 [a]) v) v
+-- | Produce a diagonal (scale) matrix from a vector.
+scale :: (Traversable t, Num a) => t a -> t (t a)
+scale v = fillFromList (choices $ traverse (\a -> SetOne 0 [a]) v) v
 
 -- | Create a unit vector.
 --


### PR DESCRIPTION
These are very abstract scale matrices. In projective spaces, we’re more used to using homogeneous coordinates. Then, such matrices should be higher. For instance, a 3D scaling (x, y, z) outputs a `M44` with the latest matrix cell set to `1`.

However, that can be achieved by simply passing `V4 x y z 1`.