### PR TITLE
Add "rotation" Lens to Linear.Matrix

### DIFF
--- a/src/Linear/Matrix.hs
+++ b/src/Linear/Matrix.hs
@@ -30,6 +30,9 @@ module Linear.Matrix
   , fromQuaternion
   , mkTransformation
   , mkTransformationMat
+  , _m22, _m23, _m24
+  , _m32, _m33, _m34
+  , _m42, _m43, _m44
   ) where
 
 import Control.Applicative
@@ -243,6 +246,51 @@ translation f rs = aux <$> f (view _w <$> view _xyz rs)
 -- translation = (. fmap (^._w)) . _xyz where
 --   x ^. l = getConst (l Const x)
 -}
+
+-- |Extract a 2x2 matrix from a matrix of higher dimensions by dropping excess
+-- rows and columns.
+_m22 :: (Representable t, R2 t, R2 v) => Lens' (t (v a)) (M22 a)
+_m22 = column _xy._xy
+
+-- |Extract a 2x3 matrix from a matrix of higher dimensions by dropping excess
+-- rows and columns.
+_m23 :: (Representable t, R2 t, R3 v) => Lens' (t (v a)) (M23 a)
+_m23 = column _xyz._xy
+
+-- |Extract a 2x4 matrix from a matrix of higher dimensions by dropping excess
+-- rows and columns.
+_m24 :: (Representable t, R2 t, R4 v) => Lens' (t (v a)) (M24 a)
+_m24 = column _xyzw._xy
+
+-- |Extract a 3x2 matrix from a matrix of higher dimensions by dropping excess
+-- rows and columns.
+_m32 :: (Representable t, R3 t, R2 v) => Lens' (t (v a)) (M32 a)
+_m32 = column _xy._xyz
+
+-- |Extract a 3x3 matrix from a matrix of higher dimensions by dropping excess
+-- rows and columns.
+_m33 :: (Representable t, R3 t, R3 v) => Lens' (t (v a)) (M33 a)
+_m33 = column _xyz._xyz
+
+-- |Extract a 3x4 matrix from a matrix of higher dimensions by dropping excess
+-- rows and columns.
+_m34 :: (Representable t, R3 t, R4 v) => Lens' (t (v a)) (M34 a)
+_m34 = column _xyzw._xyz
+
+-- |Extract a 4x2 matrix from a matrix of higher dimensions by dropping excess
+-- rows and columns.
+_m42 :: (Representable t, R4 t, R2 v) => Lens' (t (v a)) (M42 a)
+_m42 = column _xy._xyzw
+
+-- |Extract a 4x3 matrix from a matrix of higher dimensions by dropping excess
+-- rows and columns.
+_m43 :: (Representable t, R4 t, R3 v) => Lens' (t (v a)) (M43 a)
+_m43 = column _xyz._xyzw
+
+-- |Extract a 4x4 matrix from a matrix of higher dimensions by dropping excess
+-- rows and columns.
+_m44 :: (Representable t, R4 t, R4 v) => Lens' (t (v a)) (M44 a)
+_m44 = column _xyzw._xyzw
 
 -- |2x2 matrix determinant.
 --


### PR DESCRIPTION
In the vein of "translation", which gets the last column of a matrix to
obtain the translation vector, "rotation" drops all but the first three
rows and columns to obtain a 3x3 rotation matrix.