### PR TITLE
limit Binary & Serialize instances to GHC>=7.6

### DIFF
--- a/src/Linear/Plucker.hs
+++ b/src/Linear/Plucker.hs
@@ -51,7 +51,6 @@ import Control.Monad (liftM)
 import Control.Monad.Fix
 import Control.Monad.Zip
 import Control.Lens hiding (index, (<.>))
-import Data.Binary as Binary
 import Data.Bytes.Serial
 import Data.Distributive
 import Data.Foldable as Foldable
@@ -61,7 +60,6 @@ import Data.Functor.Rep
 import Data.Hashable
 import Data.Semigroup
 import Data.Semigroup.Foldable
-import Data.Serialize as Cereal
 import Foreign.Ptr (castPtr)
 import Foreign.Storable (Storable(..))
 import GHC.Arr (Ix(..))
@@ -70,6 +68,8 @@ import GHC.Generics (Generic)
 #endif
 #if defined(__GLASGOW_HASKELL__) && __GLASGOW_HASKELL__ >= 706
 import GHC.Generics (Generic1)
+import Data.Binary as Binary
+import Data.Serialize as Cereal
 #endif
 import qualified Data.Vector.Generic.Mutable as M
 import qualified Data.Vector.Generic as G
@@ -567,8 +567,10 @@ instance NFData a => NFData (Plucker a) where
   rnf (Plucker a b c d e f) = rnf a `seq` rnf b `seq` rnf c
                         `seq` rnf d `seq` rnf e `seq` rnf f
 
-instance Serial1 Plucker
 instance Serial a => Serial (Plucker a)
+
+#if defined(__GLASGOW_HASKELL__) && __GLASGOW_HASKELL__ >= 706
+instance Serial1 Plucker
 
 instance Binary a => Binary (Plucker a) where
   put = serializeWith Binary.put
@@ -577,6 +579,7 @@ instance Binary a => Binary (Plucker a) where
 instance Serialize a => Serialize (Plucker a) where
   put = serializeWith Cereal.put
   get = deserializeWith Cereal.get
+#endif
 
 instance Eq1 Plucker where eq1 = (==)
 instance Ord1 Plucker where compare1 = compare

--- a/src/Linear/Quaternion.hs
+++ b/src/Linear/Quaternion.hs
@@ -44,7 +44,6 @@ import Control.Monad (liftM)
 import Control.Monad.Fix
 import Control.Monad.Zip
 import Control.Lens hiding ((<.>))
-import Data.Binary as Binary
 import Data.Bytes.Serial
 import Data.Complex (Complex((:+)))
 import Data.Data
@@ -54,7 +53,6 @@ import Data.Functor.Bind
 import Data.Functor.Classes
 import Data.Functor.Rep
 import Data.Hashable
-import Data.Serialize as Cereal
 import GHC.Arr (Ix(..))
 import qualified Data.Foldable as F
 import Data.Monoid
@@ -65,6 +63,8 @@ import GHC.Generics (Generic)
 #endif
 #if defined(__GLASGOW_HASKELL__) && __GLASGOW_HASKELL__ >= 706
 import GHC.Generics (Generic1)
+import Data.Binary as Binary
+import Data.Serialize as Cereal
 #endif
 import qualified Data.Vector.Generic.Mutable as M
 import qualified Data.Vector.Generic as G
@@ -559,8 +559,10 @@ instance MonadFix Quaternion where
 instance NFData a => NFData (Quaternion a) where
   rnf (Quaternion a b) = rnf a `seq` rnf b
 
-instance Serial1 Quaternion
 instance Serial a => Serial (Quaternion a)
+
+#if defined(__GLASGOW_HASKELL__) && __GLASGOW_HASKELL__ >= 706
+instance Serial1 Quaternion
 
 instance Binary a => Binary (Quaternion a) where
   put = serializeWith Binary.put
@@ -569,6 +571,7 @@ instance Binary a => Binary (Quaternion a) where
 instance Serialize a => Serialize (Quaternion a) where
   put = serializeWith Cereal.put
   get = deserializeWith Cereal.get
+#endif
 
 instance Eq1 Quaternion where eq1 = (==)
 instance Ord1 Quaternion where compare1 = compare

--- a/src/Linear/V2.hs
+++ b/src/Linear/V2.hs
@@ -37,7 +37,6 @@ import Control.Monad (liftM)
 import Control.Monad.Fix
 import Control.Monad.Zip
 import Control.Lens hiding ((<.>))
-import Data.Binary as Binary
 import Data.Bytes.Serial
 import Data.Data
 import Data.Distributive
@@ -48,7 +47,6 @@ import Data.Functor.Rep
 import Data.Hashable
 import Data.Semigroup
 import Data.Semigroup.Foldable
-import Data.Serialize as Cereal
 import Foreign.Ptr (castPtr)
 import Foreign.Storable (Storable(..))
 import GHC.Arr (Ix(..))
@@ -57,6 +55,8 @@ import GHC.Generics (Generic)
 #endif
 #if defined(__GLASGOW_HASKELL__) && __GLASGOW_HASKELL__ >= 706
 import GHC.Generics (Generic1)
+import Data.Binary as Binary
+import Data.Serialize as Cereal
 #endif
 import qualified Data.Vector.Generic.Mutable as M
 import qualified Data.Vector.Generic as G
@@ -375,8 +375,10 @@ instance Bounded a => Bounded (V2 a) where
 instance NFData a => NFData (V2 a) where
   rnf (V2 a b) = rnf a `seq` rnf b
 
-instance Serial1 V2
 instance Serial a => Serial (V2 a)
+
+#if defined(__GLASGOW_HASKELL__) && __GLASGOW_HASKELL__ >= 706
+instance Serial1 V2
 
 instance Binary a => Binary (V2 a) where
   put = serializeWith Binary.put
@@ -385,6 +387,7 @@ instance Binary a => Binary (V2 a) where
 instance Serialize a => Serialize (V2 a) where
   put = serializeWith Cereal.put
   get = deserializeWith Cereal.get
+#endif
 
 instance Eq1 V2 where eq1 = (==)
 instance Ord1 V2 where compare1 = compare

--- a/src/Linear/V3.hs
+++ b/src/Linear/V3.hs
@@ -38,7 +38,6 @@ import Control.Monad (liftM)
 import Control.Monad.Fix
 import Control.Monad.Zip
 import Control.Lens hiding ((<.>))
-import Data.Binary as Binary -- binary
 import Data.Bytes.Serial -- bytes
 import Data.Data
 import Data.Distributive
@@ -49,7 +48,6 @@ import Data.Functor.Rep
 import Data.Hashable
 import Data.Semigroup
 import Data.Semigroup.Foldable
-import Data.Serialize as Cereal -- cereal
 import Foreign.Ptr (castPtr)
 import Foreign.Storable (Storable(..))
 import GHC.Arr (Ix(..))
@@ -58,6 +56,8 @@ import GHC.Generics (Generic)
 #endif
 #if defined(__GLASGOW_HASKELL__) && __GLASGOW_HASKELL__ >= 706
 import GHC.Generics (Generic1)
+import Data.Binary as Binary -- binary
+import Data.Serialize as Cereal -- cereal
 #endif
 import qualified Data.Vector.Generic.Mutable as M
 import qualified Data.Vector.Generic as G
@@ -398,8 +398,10 @@ instance Bounded a => Bounded (V3 a) where
 instance NFData a => NFData (V3 a) where
   rnf (V3 a b c) = rnf a `seq` rnf b `seq` rnf c
 
-instance Serial1 V3
 instance Serial a => Serial (V3 a)
+
+#if defined(__GLASGOW_HASKELL__) && __GLASGOW_HASKELL__ >= 706
+instance Serial1 V3
 
 instance Binary a => Binary (V3 a) where
   put = serializeWith Binary.put
@@ -408,6 +410,7 @@ instance Binary a => Binary (V3 a) where
 instance Serialize a => Serialize (V3 a) where
   put = serializeWith Cereal.put
   get = deserializeWith Cereal.get
+#endif
 
 instance Eq1 V3 where eq1 = (==)
 instance Ord1 V3 where compare1 = compare

--- a/src/Linear/V4.hs
+++ b/src/Linear/V4.hs
@@ -45,7 +45,6 @@ import Control.Monad (liftM)
 import Control.Monad.Fix
 import Control.Monad.Zip
 import Control.Lens hiding ((<.>))
-import Data.Binary as Binary
 import Data.Bytes.Serial
 import Data.Data
 import Data.Distributive
@@ -56,7 +55,6 @@ import Data.Functor.Rep
 import Data.Hashable
 import Data.Semigroup
 import Data.Semigroup.Foldable
-import Data.Serialize as Cereal
 import Foreign.Ptr (castPtr)
 import Foreign.Storable (Storable(..))
 import GHC.Arr (Ix(..))
@@ -65,6 +63,8 @@ import GHC.Generics (Generic)
 #endif
 #if defined(__GLASGOW_HASKELL__) && __GLASGOW_HASKELL__ >= 706
 import GHC.Generics (Generic1)
+import Data.Binary as Binary
+import Data.Serialize as Cereal
 #endif
 import qualified Data.Vector.Generic.Mutable as M
 import qualified Data.Vector.Generic as G
@@ -545,8 +545,10 @@ instance Bounded a => Bounded (V4 a) where
 instance NFData a => NFData (V4 a) where
   rnf (V4 a b c d) = rnf a `seq` rnf b `seq` rnf c `seq` rnf d
 
-instance Serial1 V4
 instance Serial a => Serial (V4 a)
+
+#if defined(__GLASGOW_HASKELL__) && __GLASGOW_HASKELL__ >= 706
+instance Serial1 V4
 
 instance Binary a => Binary (V4 a) where
   put = serializeWith Binary.put
@@ -555,6 +557,7 @@ instance Binary a => Binary (V4 a) where
 instance Serialize a => Serialize (V4 a) where
   put = serializeWith Cereal.put
   get = deserializeWith Cereal.get
+#endif
 
 instance Eq1 V4 where eq1 = (==)
 instance Ord1 V4 where compare1 = compare


### PR DESCRIPTION
Generic1 deriving is only available in GHC 7.6 and later.

closes #71