### PR TITLE
Added aeson instances for basic types.

### DIFF
--- a/CHANGELOG.markdown
+++ b/CHANGELOG.markdown
@@ -1,10 +1,13 @@
 1.19.?
 ------
 * Added `FromJSON` and `ToJSON` instances for several types:
+  + `V0`
+  + `V1`
   + `V2`
   + `V3`
   + `V4`
   + `Quaternion`
+  + `Plucker`
 
 1.19.1.2
 --------

--- a/CHANGELOG.markdown
+++ b/CHANGELOG.markdown
@@ -1,3 +1,11 @@
+1.19.?
+------
+* Added `FromJSON` and `ToJSON` instances for several types:
+  + `V2`
+  + `V3`
+  + `V4`
+  + `Quaternion`
+
 1.19.1.2
 --------
 * Fix GHC 7.4.

--- a/linear.cabal
+++ b/linear.cabal
@@ -39,6 +39,7 @@ source-repository head
 library
   build-depends:
     adjunctions          >= 4     && < 5,
+    aeson                >= 0.9   && < 0.10,
     base                 >= 4.5   && < 5,
     binary               >= 0.5   && < 0.8,
     bytes                >= 0.15  && < 1,

--- a/src/Linear/Plucker.hs
+++ b/src/Linear/Plucker.hs
@@ -51,6 +51,7 @@ import Control.Monad (liftM)
 import Control.Monad.Fix
 import Control.Monad.Zip
 import Control.Lens hiding (index, (<.>))
+import Data.Aeson ( FromJSON, ToJSON )
 import Data.Binary as Binary
 import Data.Bytes.Serial
 import Data.Distributive
@@ -298,6 +299,10 @@ instance Metric Plucker where
 instance Epsilon a => Epsilon (Plucker a) where
   nearZero = nearZero . quadrance
   {-# INLINE nearZero #-}
+
+instance (FromJSON a) => FromJSON (Plucker a)
+
+instance (ToJSON a) => ToJSON (Plucker a)
 
 -- | Given a pair of points represented by homogeneous coordinates
 -- generate Plücker coordinates for the line through them, directed

--- a/src/Linear/Quaternion.hs
+++ b/src/Linear/Quaternion.hs
@@ -44,6 +44,7 @@ import Control.Monad (liftM)
 import Control.Monad.Fix
 import Control.Monad.Zip
 import Control.Lens hiding ((<.>))
+import Data.Aeson ( FromJSON, ToJSON )
 import Data.Binary as Binary
 import Data.Bytes.Serial
 import Data.Complex (Complex((:+)))
@@ -265,6 +266,10 @@ instance RealFloat a => Fractional (Quaternion a) where
 instance Metric Quaternion where
   Quaternion e v `dot` Quaternion e' v' = e*e' + (v `dot` v')
   {-# INLINE dot #-}
+
+instance (FromJSON a) => FromJSON (Quaternion a)
+
+instance (ToJSON a) => ToJSON (Quaternion a)
 
 -- | A vector space that includes the basis elements '_e' and '_i'
 class Complicated t where

--- a/src/Linear/V.hs
+++ b/src/Linear/V.hs
@@ -55,6 +55,7 @@ import Control.DeepSeq (NFData)
 import Control.Monad.Fix
 import Control.Monad.Zip
 import Control.Lens as Lens
+import Data.Aeson ( FromJSON, ToJSON )
 import Data.Binary as Binary
 import Data.Bytes.Serial
 import Data.Data
@@ -202,7 +203,7 @@ instance Foldable (V n) where
   product (V as) = V.product as
   {-# INLINE product #-}
 #endif
-  
+
 
 instance FoldableWithIndex Int (V n) where
   ifoldMap f (V as) = ifoldMap f as
@@ -333,6 +334,10 @@ instance (Dim n, Epsilon a) => Epsilon (V n a) where
 instance Dim n => Metric (V n) where
   dot (V a) (V b) = V.sum $ V.zipWith (*) a b
   {-# INLINE dot #-}
+
+instance (FromJSON a) => FromJSON (V n a)
+
+instance (ToJSON a) => ToJSON (V n a)
 
 -- TODO: instance (Dim n, Ix a) => Ix (V n a)
 

--- a/src/Linear/V0.hs
+++ b/src/Linear/V0.hs
@@ -32,6 +32,7 @@ import Control.DeepSeq (NFData(rnf))
 import Control.Lens
 import Control.Monad.Fix
 import Control.Monad.Zip
+import Data.Aeson ( FromJSON, ToJSON )
 import Data.Binary -- binary
 import Data.Bytes.Serial -- bytes
 import Data.Data
@@ -247,6 +248,10 @@ instance Representable V0 where
   {-# INLINE tabulate #-}
   index xs (E l) = view l xs
   {-# INLINE index #-}
+
+instance FromJSON (V0 a)
+
+instance ToJSON (V0 a)
 
 type instance Index (V0 a) = E V0
 type instance IxValue (V0 a) = a

--- a/src/Linear/V1.hs
+++ b/src/Linear/V1.hs
@@ -40,6 +40,7 @@ import Control.Monad (liftM)
 import Control.Monad.Fix
 import Control.Monad.Zip
 import Control.Lens
+import Data.Aeson ( FromJSON, ToJSON )
 import Data.Binary as Binary
 import Data.Bytes.Serial
 import Data.Serialize as Cereal
@@ -210,6 +211,10 @@ instance Hashable a => Hashable (V1 a) where
 instance Metric V1 where
   dot (V1 a) (V1 b) = a * b
   {-# INLINE dot #-}
+
+instance (FromJSON a) => FromJSON (V1 a)
+
+instance (ToJSON a) => ToJSON (V1 a)
 
 -- | A space that has at least 1 basis vector '_x'.
 class R1 t where

--- a/src/Linear/V2.hs
+++ b/src/Linear/V2.hs
@@ -37,6 +37,7 @@ import Control.Monad (liftM)
 import Control.Monad.Fix
 import Control.Monad.Zip
 import Control.Lens hiding ((<.>))
+import Data.Aeson ( FromJSON, ToJSON )
 import Data.Binary as Binary
 import Data.Bytes.Serial
 import Data.Data
@@ -217,6 +218,10 @@ instance Floating a => Floating (V2 a) where
 instance Metric V2 where
   dot (V2 a b) (V2 c d) = a * c + b * d
   {-# INLINE dot #-}
+
+instance (FromJSON a) => FromJSON (V2 a)
+
+instance (ToJSON a) => ToJSON (V2 a)
 
 -- | A space that distinguishes 2 orthogonal basis vectors '_x' and '_y', but may have more.
 class R1 t => R2 t where

--- a/src/Linear/V3.hs
+++ b/src/Linear/V3.hs
@@ -38,6 +38,7 @@ import Control.Monad (liftM)
 import Control.Monad.Fix
 import Control.Monad.Zip
 import Control.Lens hiding ((<.>))
+import Data.Aeson ( FromJSON, ToJSON )
 import Data.Binary as Binary -- binary
 import Data.Bytes.Serial -- bytes
 import Data.Data
@@ -209,6 +210,10 @@ instance Metric V3 where
 instance Distributive V3 where
   distribute f = V3 (fmap (\(V3 x _ _) -> x) f) (fmap (\(V3 _ y _) -> y) f) (fmap (\(V3 _ _ z) -> z) f)
   {-# INLINE distribute #-}
+
+instance (FromJSON a) => FromJSON (V3 a)
+
+instance (ToJSON a) => ToJSON (V3 a)
 
 -- | A space that distinguishes 3 orthogonal basis vectors: '_x', '_y', and '_z'. (It may have more)
 class R2 t => R3 t where

--- a/src/Linear/V4.hs
+++ b/src/Linear/V4.hs
@@ -45,6 +45,7 @@ import Control.Monad (liftM)
 import Control.Monad.Fix
 import Control.Monad.Zip
 import Control.Lens hiding ((<.>))
+import Data.Aeson ( FromJSON, ToJSON )
 import Data.Binary as Binary
 import Data.Bytes.Serial
 import Data.Data
@@ -221,6 +222,10 @@ instance Distributive V4 where
 instance Hashable a => Hashable (V4 a) where
   hashWithSalt s (V4 a b c d) = s `hashWithSalt` a `hashWithSalt` b `hashWithSalt` c `hashWithSalt` d
   {-# INLINE hashWithSalt #-}
+
+instance (FromJSON a) => FromJSON (V4 a)
+
+instance (ToJSON a) => ToJSON (V4 a)
 
 -- | A space that distinguishes orthogonal basis vectors '_x', '_y', '_z', '_w'. (It may have more.)
 class R3 t => R4 t where


### PR DESCRIPTION
V2, V3, V4 and Quaternion. Implemented with Generic. The CHANGELOG was modified according to the changes, but I let the minor version to **?** so that you can add other stuff to that new version if you want to – like more aeson instances I don’t think of.