### PR TITLE
add preprocessor stuff for instances that will be added in the next GHC?

### DIFF
--- a/src/Linear/Instances.hs
+++ b/src/Linear/Instances.hs
@@ -43,16 +43,20 @@ instance (Hashable k, Eq k) => Bind (HashMap k) where
       Just b -> [(k,b)]
       Nothing -> []
 
+#if __GLASGOW_HASKELL__ < 711
 instance Functor Complex where
   fmap f (a :+ b) = f a :+ f b
   {-# INLINE fmap #-}
+#endif
 
 instance Apply Complex where
   (a :+ b) <.> (c :+ d) = a c :+ b d
 
+#if __GLASGOW_HASKELL__ < 711
 instance Applicative Complex where
   pure a = a :+ a
   (a :+ b) <*> (c :+ d) = a c :+ b d
+#endif
 
 instance Bind Complex where
   (a :+ b) >>- f = a' :+ b' where
@@ -60,6 +64,7 @@ instance Bind Complex where
     _  :+ b' = f b
   {-# INLINE (>>-) #-}
 
+#if __GLASGOW_HASKELL__ < 711
 instance Monad Complex where
   return a = a :+ a
   {-# INLINE return #-}
@@ -68,6 +73,7 @@ instance Monad Complex where
     a' :+ _  = f a
     _  :+ b' = f b
   {-# INLINE (>>=) #-}
+#endif
 
 instance MonadZip Complex where
   mzipWith = liftA2
@@ -75,6 +81,7 @@ instance MonadZip Complex where
 instance MonadFix Complex where
   mfix f = (let a :+ _ = f a in a) :+ (let _ :+ a = f a in a)
 
+#if __GLASGOW_HASKELL__ < 711
 instance Foldable Complex where
   foldMap f (a :+ b) = f a `mappend` f b
   {-# INLINE foldMap #-}
@@ -82,6 +89,7 @@ instance Foldable Complex where
 instance Traversable Complex where
   traverse f (a :+ b) = (:+) <$> f a <*> f b
   {-# INLINE traverse #-}
+#endif
 
 instance Foldable1 Complex where
   foldMap1 f (a :+ b) = f a <> f b


### PR DESCRIPTION
I dunno if it's too early to bother, but I saw in the travis-ci build for one of my repos that linear failed on GHC HEAD because of duplicate instances.