### PR TITLE
Bump vector version, for imapM_.

### DIFF
--- a/CHANGELOG.markdown
+++ b/CHANGELOG.markdown
@@ -1,3 +1,5 @@
+* Require `vector` 0.11.0.0.
+
 1.20.2
 ------
 * Modified the `doctest` machinery to work with `stack` and builds to non-standard locations.

--- a/linear.cabal
+++ b/linear.cabal
@@ -60,7 +60,7 @@ library
     transformers         >= 0.2   && < 0.5,
     transformers-compat  >= 0.4   && < 1,
     unordered-containers >= 0.2.3 && < 0.3,
-    vector               >= 0.10  && < 0.12,
+    vector               >= 0.11  && < 0.12,
     void                 >= 0.6   && < 1
 
   if flag(template-haskell) && impl(ghc)


### PR DESCRIPTION
It seems `imapM_` is not available before 0.11.