### PR TITLE
Consolidate orphan Complex instances with base-orphans

### DIFF
--- a/linear.cabal
+++ b/linear.cabal
@@ -44,6 +44,7 @@ library
   build-depends:
     adjunctions          >= 4     && < 5,
     base                 >= 4.5   && < 5,
+    base-orphans         >= 0.5   && < 1,
     binary               >= 0.5   && < 0.8,
     bytes                >= 0.15  && < 1,
     cereal               >= 0.4.1.1 && < 0.6,

--- a/src/Linear/Instances.hs
+++ b/src/Linear/Instances.hs
@@ -19,18 +19,13 @@ import Control.Applicative
 import Control.Monad.Fix
 import Control.Monad.Zip
 import Data.Complex
-#if __GLASGOW_HASKELL__ < 710
-import Data.Foldable
-#endif
 import Data.Functor.Bind
 import Data.HashMap.Lazy as HashMap
 import Data.Hashable
+import Data.Orphans ()
 import Data.Semigroup
 import Data.Semigroup.Foldable
 import Data.Semigroup.Traversable
-#if __GLASGOW_HASKELL__ < 710
-import Data.Traversable
-#endif
 
 instance (Hashable k, Eq k) => Apply (HashMap k) where
   (<.>) = HashMap.intersectionWith id
@@ -43,20 +38,8 @@ instance (Hashable k, Eq k) => Bind (HashMap k) where
       Just b -> [(k,b)]
       Nothing -> []
 
-#if __GLASGOW_HASKELL__ < 711
-instance Functor Complex where
-  fmap f (a :+ b) = f a :+ f b
-  {-# INLINE fmap #-}
-#endif
-
 instance Apply Complex where
   (a :+ b) <.> (c :+ d) = a c :+ b d
-
-#if __GLASGOW_HASKELL__ < 711
-instance Applicative Complex where
-  pure a = a :+ a
-  (a :+ b) <*> (c :+ d) = a c :+ b d
-#endif
 
 instance Bind Complex where
   (a :+ b) >>- f = a' :+ b' where
@@ -64,32 +47,11 @@ instance Bind Complex where
     _  :+ b' = f b
   {-# INLINE (>>-) #-}
 
-#if __GLASGOW_HASKELL__ < 711
-instance Monad Complex where
-  return a = a :+ a
-  {-# INLINE return #-}
-
-  (a :+ b) >>= f = a' :+ b' where
-    a' :+ _  = f a
-    _  :+ b' = f b
-  {-# INLINE (>>=) #-}
-#endif
-
 instance MonadZip Complex where
   mzipWith = liftA2
 
 instance MonadFix Complex where
   mfix f = (let a :+ _ = f a in a) :+ (let _ :+ a = f a in a)
-
-#if __GLASGOW_HASKELL__ < 711
-instance Foldable Complex where
-  foldMap f (a :+ b) = f a `mappend` f b
-  {-# INLINE foldMap #-}
-
-instance Traversable Complex where
-  traverse f (a :+ b) = (:+) <$> f a <*> f b
-  {-# INLINE traverse #-}
-#endif
 
 instance Foldable1 Complex where
   foldMap1 f (a :+ b) = f a <> f b


### PR DESCRIPTION
`base-orphans-0.5` now backports the orphan `Functor`/`Foldable`/`Traversable`/`Applicative`/`Monad` instances for `Complex` introduced in `base-4.9`.