### PR TITLE
Doctest ghc 8

### DIFF
--- a/linear.cabal
+++ b/linear.cabal
@@ -107,18 +107,15 @@ library
 test-suite doctests
   type:           exitcode-stdio-1.0
   main-is:        doctests.hs
-  if impl(ghc >= 8)
-    buildable: False
-  else
-    ghc-options:    -Wall -threaded
-    hs-source-dirs: tests
-    build-depends:
-      base,
-      directory >= 1.0 && < 1.3,
-      doctest   >= 0.8 && < 0.11,
-      filepath  >= 1.3 && < 1.5,
-      lens,
-      simple-reflect >= 0.3.1
+  ghc-options:    -Wall -threaded
+  hs-source-dirs: tests
+  build-depends:
+    base,
+    directory >= 1.0 && < 1.3,
+    doctest   >= 0.8 && < 0.11,
+    filepath  >= 1.3 && < 1.5,
+    lens,
+    simple-reflect >= 0.3.1
 
 test-suite UnitTests
   type:           exitcode-stdio-1.0

--- a/linear.cabal
+++ b/linear.cabal
@@ -112,7 +112,7 @@ test-suite doctests
   build-depends:
     base,
     directory >= 1.0 && < 1.3,
-    doctest   >= 0.8 && < 0.11,
+    doctest   >= 0.11 && < 0.12,
     filepath  >= 1.3 && < 1.5,
     lens,
     simple-reflect >= 0.3.1


### PR DESCRIPTION
Newest `doctest` supports GHC-8, and the tests pass for me with `GHC-8-rc3`.  Can we re-enable the doctests?