### PR TITLE
Add crossZ (Z-component of cross product) for V2

### DIFF
--- a/src/Linear/V2.hs
+++ b/src/Linear/V2.hs
@@ -39,6 +39,7 @@ module Linear.V2
   , ex, ey
   , perp
   , angle
+  , crossZ
   ) where
 
 import Control.Applicative
@@ -390,6 +391,14 @@ instance MonadFix V2 where
 
 angle :: Floating a => a -> V2 a
 angle a = V2 (cos a) (sin a)
+
+-- | The Z-component of the cross product of two vectors in the XY-plane.
+--
+-- >>> crossZ (V2 1 0) (V2 0 1)
+-- 1
+crossZ :: Num a => V2 a -> V2 a -> a
+crossZ (V2 x1 y1) (V2 x2 y2) = (x1 * y2) - (y1 * x2)
+{-# INLINE crossZ #-}
 
 instance Bounded a => Bounded (V2 a) where
   minBound = pure minBound


### PR DESCRIPTION
This is commonly used to distinguish between left and right turns in 2D.