### PR TITLE
!* operator aught to be right-associative

### DIFF
--- a/src/Linear/Matrix.hs
+++ b/src/Linear/Matrix.hs
@@ -107,7 +107,7 @@ infixl 6 !-!
 (!-!) :: (Additive m, Additive n, Num a) => m (n a) -> m (n a) -> m (n a)
 as !-! bs = liftU2 (^-^) as bs
 
-infixl 7 !*
+infixr 7 !*
 -- | Matrix * column vector
 --
 -- >>> V2 (V3 1 2 3) (V3 4 5 6) !* V3 7 8 9


### PR DESCRIPTION
I believe that most people would expect that `!*`, being a matrix-vector product, would bracket this way:

```haskell
let m = _ :: M22 a
    n = _ :: M22 a
    v = _ :: V2 a
```
```haskell
m !* (n !* v)
```

In fact, `!*` is infixl, causing it to bracket from the left:

```haskell
(m !* n) !* v
```

Fortunately these two are equivalent, however the `m !* (n !* v)` form aught to be much more efficient.

---
Note: Just to dot all our i's and cross all our t's... Notice that there is no effect on the performance for an expression that has the vector in the left-most position (a surprising, but well-typed, use of the `!*` operator). I.e.

```haskell
v !* (m !* n)
```

has exactly the same number of operations as 

```haskell
(v !* m) !* n
```