### PR TITLE
Relax directory constraint

### DIFF
--- a/linear.cabal
+++ b/linear.cabal
@@ -111,7 +111,7 @@ test-suite doctests
   hs-source-dirs: tests
   build-depends:
     base,
-    directory >= 1.0 && < 1.3,
+    directory >= 1.0 && < 1.4,
     doctest   >= 0.8 && < 0.12,
     filepath  >= 1.3 && < 1.5,
     lens,


### PR DESCRIPTION
`1.3` is shipped with GHC 8.0.2