### PR TITLE
Enable 'PolyKinds' in Linear.Trace

### DIFF
--- a/src/Linear/Trace.hs
+++ b/src/Linear/Trace.hs
@@ -1,6 +1,9 @@
 {-# LANGUAGE CPP #-}
 {-# LANGUAGE TypeOperators #-}
 {-# LANGUAGE DefaultSignatures #-}
+#if __GLASGOW_HASKELL__ >= 707
+{-# LANGUAGE PolyKinds #-}
+#endif
 #if __GLASGOW_HASKELL__ >= 702 && __GLASGOW_HASKELL__ < 710
 {-# LANGUAGE Trustworthy #-}
 #endif


### PR DESCRIPTION
This turns on `PolyKinds` for appropriate GHC versions in `Linear.Trace`. The particular motivation is to generalize

```haskell
instance Dim * n => Trace (V * n)
```

to the kind `Nat`, such that `trace m` compiles for types like `m :: V 5 (V 5 Double)`.

Fixes #121.