### PR TITLE
Derive V0-V4 instances for the TH Lift class.

### DIFF
--- a/src/Linear/Plucker.hs
+++ b/src/Linear/Plucker.hs
@@ -12,6 +12,10 @@
 {-# LANGUAGE DataKinds #-}
 #endif
 
+#if __GLASGOW_HASKELL__ >= 800
+{-# LANGUAGE DeriveLift #-}
+#endif
+
 #ifndef MIN_VERSION_vector
 #define MIN_VERSION_vector(x,y,z) 1
 #endif
@@ -88,6 +92,9 @@ import GHC.Generics (Generic)
 #if __GLASGOW_HASKELL__ >= 706
 import GHC.Generics (Generic1)
 #endif
+#if __GLASGOW_HASKELL__ >= 800
+import Language.Haskell.TH.Syntax (Lift)
+#endif
 import Linear.Epsilon
 import Linear.Metric
 #if __GLASGOW_HASKELL__ >= 707
@@ -107,6 +114,9 @@ data Plucker a = Plucker !a !a !a !a !a !a deriving (Eq,Ord,Show,Read
 #endif
 #if __GLASGOW_HASKELL__ >= 706
                                                     ,Generic1
+#endif
+#if __GLASGOW_HASKELL__ >= 800
+                                                    ,Lift
 #endif
                                                     )
 

--- a/src/Linear/Quaternion.hs
+++ b/src/Linear/Quaternion.hs
@@ -13,6 +13,10 @@
 {-# LANGUAGE DataKinds #-}
 #endif
 
+#if __GLASGOW_HASKELL__ >= 800
+{-# LANGUAGE DeriveLift #-}
+#endif
+
 #ifndef MIN_VERSION_hashable
 #define MIN_VERSION_hashable(x,y,z) 1
 #endif
@@ -86,6 +90,9 @@ import GHC.Generics (Generic)
 #if __GLASGOW_HASKELL__ >= 706
 import GHC.Generics (Generic1)
 #endif
+#if __GLASGOW_HASKELL__ >= 800
+import Language.Haskell.TH.Syntax (Lift)
+#endif
 import Linear.Epsilon
 import Linear.Conjugate
 import Linear.Metric
@@ -106,6 +113,9 @@ data Quaternion a = Quaternion !a {-# UNPACK #-}!(V3 a)
 #endif
 #if defined(__GLASGOW_HASKELL__) && __GLASGOW_HASKELL__ >= 706
                              ,Generic1
+#endif
+#if __GLASGOW_HASKELL__ >= 800
+                             ,Lift
 #endif
                              )
 

--- a/src/Linear/V0.hs
+++ b/src/Linear/V0.hs
@@ -14,6 +14,10 @@
 {-# LANGUAGE DataKinds #-}
 #endif
 
+#if __GLASGOW_HASKELL__ >= 800
+{-# LANGUAGE DeriveLift #-}
+#endif
+
 #ifndef MIN_VERSION_hashable
 #define MIN_VERSION_hashable(x,y,z) 1
 #endif
@@ -74,6 +78,9 @@ import GHC.Generics (Generic)
 #if __GLASGOW_HASKELL__ >= 706
 import GHC.Generics (Generic1)
 #endif
+#if __GLASGOW_HASKELL__ >= 800
+import Language.Haskell.TH.Syntax (Lift)
+#endif
 import qualified Data.Vector.Generic.Mutable as M
 import qualified Data.Vector.Generic as G
 import qualified Data.Vector.Unboxed.Base as U
@@ -102,6 +109,9 @@ data V0 a = V0 deriving (Eq,Ord,Show,Read,Ix,Enum,Data,Typeable
 #endif
 #if defined(__GLASGOW_HASKELL__) && __GLASGOW_HASKELL__ >= 706
                         ,Generic1
+#endif
+#if __GLASGOW_HASKELL__ >= 800
+                        ,Lift
 #endif
                         )
 

--- a/src/Linear/V1.hs
+++ b/src/Linear/V1.hs
@@ -16,6 +16,10 @@
 {-# LANGUAGE DataKinds #-}
 #endif
 
+#if __GLASGOW_HASKELL__ >= 800
+{-# LANGUAGE DeriveLift #-}
+#endif
+
 #ifndef MIN_VERSION_hashable
 #define MIN_VERSION_hashable(x,y,z) 1
 #endif
@@ -77,6 +81,9 @@ import GHC.Generics (Generic)
 #if __GLASGOW_HASKELL__ >= 706
 import GHC.Generics (Generic1)
 #endif
+#if __GLASGOW_HASKELL__ >= 800
+import Language.Haskell.TH.Syntax (Lift)
+#endif
 import Linear.Metric
 import Linear.Epsilon
 import Linear.Vector
@@ -118,6 +125,9 @@ newtype V1 a = V1 a
 #endif
 #if defined(__GLASGOW_HASKELL__) && __GLASGOW_HASKELL__ >= 706
            ,Generic1
+#endif
+#if __GLASGOW_HASKELL__ >= 800
+           ,Lift
 #endif
            )
 

--- a/src/Linear/V2.hs
+++ b/src/Linear/V2.hs
@@ -13,6 +13,10 @@
 {-# LANGUAGE DataKinds #-}
 #endif
 
+#if __GLASGOW_HASKELL__ >= 800
+{-# LANGUAGE DeriveLift #-}
+#endif
+
 #ifndef MIN_VERSION_hashable
 #define MIN_VERSION_hashable(x,y,z) 1
 #endif
@@ -81,6 +85,9 @@ import GHC.Generics (Generic)
 #if __GLASGOW_HASKELL__ >= 706
 import GHC.Generics (Generic1)
 #endif
+#if __GLASGOW_HASKELL__ >= 800
+import Language.Haskell.TH.Syntax (Lift)
+#endif
 import qualified Data.Vector.Generic.Mutable as M
 import qualified Data.Vector.Generic as G
 import qualified Data.Vector.Unboxed.Base as U
@@ -117,6 +124,9 @@ data V2 a = V2 !a !a deriving
 #endif
 #if defined(__GLASGOW_HASKELL__) && __GLASGOW_HASKELL__ >= 706
   ,Generic1
+#endif
+#if __GLASGOW_HASKELL__ >= 800
+  ,Lift
 #endif
   )
 

--- a/src/Linear/V3.hs
+++ b/src/Linear/V3.hs
@@ -13,6 +13,10 @@
 {-# LANGUAGE DataKinds #-}
 #endif
 
+#if __GLASGOW_HASKELL__ >= 800
+{-# LANGUAGE DeriveLift #-}
+#endif
+
 #ifndef MIN_VERSION_hashable
 #define MIN_VERSION_hashable(x,y,z) 1
 #endif
@@ -86,6 +90,9 @@ import GHC.Generics (Generic)
 #if __GLASGOW_HASKELL__ >= 706
 import GHC.Generics (Generic1)
 #endif
+#if __GLASGOW_HASKELL__ >= 800
+import Language.Haskell.TH.Syntax (Lift)
+#endif
 import Linear.Epsilon
 import Linear.Metric
 #if __GLASGOW_HASKELL__ >= 707
@@ -103,6 +110,9 @@ data V3 a = V3 !a !a !a deriving (Eq,Ord,Show,Read,Data,Typeable
 #endif
 #if __GLASGOW_HASKELL__ >= 706
                                  ,Generic1
+#endif
+#if __GLASGOW_HASKELL__ >= 800
+                                 ,Lift
 #endif
                                  )
 

--- a/src/Linear/V4.hs
+++ b/src/Linear/V4.hs
@@ -13,6 +13,10 @@
 {-# LANGUAGE DataKinds #-}
 #endif
 
+#if __GLASGOW_HASKELL__ >= 800
+{-# LANGUAGE DeriveLift #-}
+#endif
+
 #ifndef MIN_VERSION_hashable
 #define MIN_VERSION_hashable(x,y,z) 1
 #endif
@@ -92,6 +96,9 @@ import GHC.Generics (Generic)
 #if __GLASGOW_HASKELL__ >= 706
 import GHC.Generics (Generic1)
 #endif
+#if __GLASGOW_HASKELL__ >= 800
+import Language.Haskell.TH.Syntax (Lift)
+#endif
 import Linear.Epsilon
 import Linear.Metric
 #if __GLASGOW_HASKELL__ >= 707
@@ -110,6 +117,9 @@ data V4 a = V4 !a !a !a !a deriving (Eq,Ord,Show,Read,Data,Typeable
 #endif
 #if __GLASGOW_HASKELL__ >= 706
                                     ,Generic1
+#endif
+#if __GLASGOW_HASKELL__ >= 800
+                                    ,Lift
 #endif
                                     )
 


### PR DESCRIPTION
The [`Lift` class](http://hackage.haskell.org/package/template-haskell-2.14.0.0/docs/Language-Haskell-TH-Syntax.html#t:Lift) allows easily using vectors in source code that have been pre-computed at compile time, i.e. in Template Haskell splices.