### PR TITLE
Allow building with random-1.2.*

### DIFF
--- a/linear.cabal
+++ b/linear.cabal
@@ -70,7 +70,7 @@ library
     ghc-prim,
     hashable             >= 1.1   && < 1.4,
     lens                 >= 4.15.2 && < 5,
-    random               >= 1.0   && < 1.2,
+    random               >= 1.0   && < 1.3,
     reflection           >= 1.3.2 && < 3,
     semigroups           >= 0.9   && < 1,
     semigroupoids        >= 5.2.1 && < 6,

--- a/src/Linear/V0.hs
+++ b/src/Linear/V0.hs
@@ -131,8 +131,6 @@ instance Random (V0 a) where
   randomR _ g = (V0, g)
   randomRs _ _ = repeat V0
   randoms _ = repeat V0
-  randomRIO _ = pure V0
-  randomIO = pure V0
 
 instance Serial1 V0 where
   serializeWith _ = serialize

--- a/src/Linear/V1.hs
+++ b/src/Linear/V1.hs
@@ -405,7 +405,6 @@ instance Random a => Random (V1 a) where
   randoms g = V1 <$> randoms g
   randomR (V1 a, V1 b) g = case randomR (a, b) g of (a', g') -> (V1 a', g')
   randomRs (V1 a, V1 b) g = V1 <$> randomRs (a, b) g
-  randomIO = V1 <$> randomIO
 
 #if (MIN_VERSION_transformers(0,5,0)) || !(MIN_VERSION_transformers(0,4,0))
 instance Eq1 V1 where


### PR DESCRIPTION
`random-1.2.0` removes the `randomIO` and `randomRIO` methods from `Random`. All previous releases of `random` have sensible default implementations for these methods, so they can be omitted.