### PR TITLE
Use base-orphans-0.8.3's orphan MonadFix/MonadZip instances for Complex

### DIFF
--- a/linear.cabal
+++ b/linear.cabal
@@ -60,7 +60,7 @@ library
   build-depends:
     adjunctions          >= 4     && < 5,
     base                 >= 4.5   && < 5,
-    base-orphans         >= 0.5   && < 1,
+    base-orphans         >= 0.8.3 && < 1,
     binary               >= 0.5   && < 0.9,
     bytes                >= 0.15  && < 1,
     cereal               >= 0.4.1.1 && < 0.6,

--- a/src/Linear/Instances.hs
+++ b/src/Linear/Instances.hs
@@ -1,8 +1,4 @@
-{-# OPTIONS_GHC -fno-warn-orphans #-}
-{-# LANGUAGE CPP #-}
-#if __GLASGOW_HASKELL__ >= 702 && __GLASGOW_HASKELL__ < 710
-{-# LANGUAGE Trustworthy #-}
-#endif
+{-# LANGUAGE Safe #-}
 -----------------------------------------------------------------------------
 -- |
 -- Copyright   :  (C) 2012-2015 Edward Kmett
@@ -11,18 +7,8 @@
 -- Stability   :  provisional
 -- Portability :  portable
 --
--- Orphans
+-- Re-exports orphan instances for @Complex@ from the @base-orphans@ package.
 -----------------------------------------------------------------------------
 module Linear.Instances () where
 
-import Control.Applicative
-import Control.Monad.Fix
-import Control.Monad.Zip
-import Data.Complex
 import Data.Orphans ()
-
-instance MonadZip Complex where
-  mzipWith = liftA2
-
-instance MonadFix Complex where
-  mfix f = (let a :+ _ = f a in a) :+ (let _ :+ a = f a in a)


### PR DESCRIPTION
`base-orphans-0.8.3` now backports the `MonadFix` and `MonadZip` instances for `Complex` (newly added to `base-4.15.0.0`) to older versions of `base`. As a result, we no longer need to define these instances as orphans in `Linear.Instances`, which allows us to turn that module into a simple shim on top of `Data.Orphans`.