### PR TITLE
Specify 'foldMap' from Data.Foldable rather than Data.Vector.

### DIFF
--- a/src/Linear/V.hs
+++ b/src/Linear/V.hs
@@ -235,7 +235,7 @@ instance FunctorWithIndex Int (V n) where
 instance Foldable (V n) where
   fold (V as) = fold as
   {-# INLINE fold #-}
-  foldMap f (V as) = P.foldMap f as
+  foldMap f (V as) = Foldable.foldMap f as
   {-# INLINE foldMap #-}
   foldr f z (V as) = V.foldr f z as
   {-# INLINE foldr #-}

--- a/src/Linear/V.hs
+++ b/src/Linear/V.hs
@@ -235,7 +235,7 @@ instance FunctorWithIndex Int (V n) where
 instance Foldable (V n) where
   fold (V as) = fold as
   {-# INLINE fold #-}
-  foldMap f (V as) = V.foldMap f as
+  foldMap f (V as) = P.foldMap f as
   {-# INLINE foldMap #-}
   foldr f z (V as) = V.foldr f z as
   {-# INLINE foldr #-}

--- a/src/Linear/V.hs
+++ b/src/Linear/V.hs
@@ -235,7 +235,7 @@ instance FunctorWithIndex Int (V n) where
 instance Foldable (V n) where
   fold (V as) = fold as
   {-# INLINE fold #-}
-  foldMap f (V as) = P.foldMap f as
+  foldMap f (V as) = V.foldMap f as
   {-# INLINE foldMap #-}
   foldr f z (V as) = V.foldr f z as
   {-# INLINE foldr #-}

--- a/src/Linear/V.hs
+++ b/src/Linear/V.hs
@@ -235,7 +235,7 @@ instance FunctorWithIndex Int (V n) where
 instance Foldable (V n) where
   fold (V as) = fold as
   {-# INLINE fold #-}
-  foldMap f (V as) = foldMap f as
+  foldMap f (V as) = P.foldMap f as
   {-# INLINE foldMap #-}
   foldr f z (V as) = V.foldr f z as
   {-# INLINE foldr #-}


### PR DESCRIPTION
`vector-0.12.2.0` (released today) exports `foldMap` which is different from `Data.Foldable.foldMap`. This breaks the compilation of `linear`. The fix is simple: qualify the use of `foldMap`.