### PR TITLE
Fix the build with random-1.2.1+ 

### DIFF
--- a/.github/workflows/haskell-ci.yml
+++ b/.github/workflows/haskell-ci.yml
@@ -17,31 +17,6 @@ on:
   - push
   - pull_request
 jobs:
-  irc:
-    name: Haskell-CI (IRC notification)
-    runs-on: ubuntu-18.04
-    needs:
-      - linux
-    if: ${{ always() && (github.repository == 'ekmett/linear') }}
-    strategy:
-      fail-fast: false
-    steps:
-      - name: IRC success notification (irc.freenode.org#haskell-lens)
-        uses: Gottox/irc-message-action@v1.1
-        if: needs.linux.result == 'success'
-        with:
-          channel: "#haskell-lens"
-          message: "\x0313linear\x03/\x0306${{ github.ref }}\x03 \x0314${{ github.sha }}\x03 https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }} The build succeeded."
-          nickname: github-actions
-          server: irc.freenode.org
-      - name: IRC failure notification (irc.freenode.org#haskell-lens)
-        uses: Gottox/irc-message-action@v1.1
-        if: needs.linux.result != 'success'
-        with:
-          channel: "#haskell-lens"
-          message: "\x0313linear\x03/\x0306${{ github.ref }}\x03 \x0314${{ github.sha }}\x03 https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }} The build failed."
-          nickname: github-actions
-          server: irc.freenode.org
   linux:
     name: Haskell-CI - Linux - ${{ matrix.compiler }}
     runs-on: ubuntu-18.04
@@ -140,7 +115,7 @@ jobs:
       - name: cache (tools)
         uses: actions/cache@v2
         with:
-          key: ${{ runner.os }}-${{ matrix.compiler }}-tools-33871eb4
+          key: ${{ runner.os }}-${{ matrix.compiler }}-tools-2b1b586f
           path: ~/.haskell-ci-tools
       - name: install cabal-plan
         run: |
@@ -162,10 +137,10 @@ jobs:
           cabal-docspec --version
       - name: install hlint
         run: |
-          if [ $((HCNUMVER >= 81000 && HCNUMVER < 90000)) -ne 0 ] ; then HLINTVER=$(cd /tmp && (${CABAL} v2-install -v $ARG_COMPILER --dry-run hlint  --constraint='hlint >=3.3 && <3.4' |  perl -ne 'if (/\bhlint-(\d+(\.\d+)*)\b/) { print "$1"; last; }')); echo "HLint version $HLINTVER" ; fi
-          if [ $((HCNUMVER >= 81000 && HCNUMVER < 90000)) -ne 0 ] ; then if [ ! -e $HOME/.haskell-ci-tools/hlint-$HLINTVER/hlint ]; then echo "Downloading HLint version $HLINTVER"; mkdir -p $HOME/.haskell-ci-tools; curl --write-out 'Status Code: %{http_code} Redirects: %{num_redirects} Total time: %{time_total} Total Dsize: %{size_download}\n' --silent --location --output $HOME/.haskell-ci-tools/hlint-$HLINTVER.tar.gz "https://github.com/ndmitchell/hlint/releases/download/v$HLINTVER/hlint-$HLINTVER-x86_64-linux.tar.gz"; tar -xzv -f $HOME/.haskell-ci-tools/hlint-$HLINTVER.tar.gz -C $HOME/.haskell-ci-tools; fi ; fi
-          if [ $((HCNUMVER >= 81000 && HCNUMVER < 90000)) -ne 0 ] ; then mkdir -p $CABAL_DIR/bin && ln -sf "$HOME/.haskell-ci-tools/hlint-$HLINTVER/hlint" $CABAL_DIR/bin/hlint ; fi
-          if [ $((HCNUMVER >= 81000 && HCNUMVER < 90000)) -ne 0 ] ; then hlint --version ; fi
+          if [ $((HCNUMVER >= 90000)) -ne 0 ] ; then HLINTVER=$(cd /tmp && (${CABAL} v2-install -v $ARG_COMPILER --dry-run hlint  --constraint='hlint >=3.3 && <3.4' |  perl -ne 'if (/\bhlint-(\d+(\.\d+)*)\b/) { print "$1"; last; }')); echo "HLint version $HLINTVER" ; fi
+          if [ $((HCNUMVER >= 90000)) -ne 0 ] ; then if [ ! -e $HOME/.haskell-ci-tools/hlint-$HLINTVER/hlint ]; then echo "Downloading HLint version $HLINTVER"; mkdir -p $HOME/.haskell-ci-tools; curl --write-out 'Status Code: %{http_code} Redirects: %{num_redirects} Total time: %{time_total} Total Dsize: %{size_download}\n' --silent --location --output $HOME/.haskell-ci-tools/hlint-$HLINTVER.tar.gz "https://github.com/ndmitchell/hlint/releases/download/v$HLINTVER/hlint-$HLINTVER-x86_64-linux.tar.gz"; tar -xzv -f $HOME/.haskell-ci-tools/hlint-$HLINTVER.tar.gz -C $HOME/.haskell-ci-tools; fi ; fi
+          if [ $((HCNUMVER >= 90000)) -ne 0 ] ; then mkdir -p $CABAL_DIR/bin && ln -sf "$HOME/.haskell-ci-tools/hlint-$HLINTVER/hlint" $CABAL_DIR/bin/hlint ; fi
+          if [ $((HCNUMVER >= 90000)) -ne 0 ] ; then hlint --version ; fi
       - name: checkout
         uses: actions/checkout@v2
         with:
@@ -223,7 +198,7 @@ jobs:
           cabal-docspec $ARG_COMPILER
       - name: hlint
         run: |
-          if [ $((HCNUMVER >= 81000 && HCNUMVER < 90000)) -ne 0 ] ; then (cd ${PKGDIR_linear} && hlint src) ; fi
+          if [ $((HCNUMVER >= 90000)) -ne 0 ] ; then (cd ${PKGDIR_linear} && hlint src) ; fi
       - name: cabal check
         run: |
           cd ${PKGDIR_linear} || false

--- a/.hlint.yaml
+++ b/.hlint.yaml
@@ -2,3 +2,4 @@
 - ignore: {name: Avoid lambda}
 - ignore: {name: Redundant lambda}
 - ignore: {name: Unused LANGUAGE pragma}
+- ignore: {name: Eta reduce, within: [Linear.Plucker, Linear.Quaternion, Linear.V, Linear.V0, Linear.V1, Linear.V2, Linear.V3, Linear.V4]}

--- a/cabal.haskell-ci
+++ b/cabal.haskell-ci
@@ -2,8 +2,7 @@ distribution:           bionic
 no-tests-no-benchmarks: False
 unconstrained:          False
 hlint:                  True
-hlint-job:              8.10.4
-irc-channels:           irc.freenode.org#haskell-lens
+-- irc-channels:           irc.freenode.org#haskell-lens
 irc-if-in-origin-repo:  True
 docspec:                True
 

--- a/src/Linear/Affine.hs
+++ b/src/Linear/Affine.hs
@@ -86,7 +86,7 @@ import Linear.V2
 import Linear.V3
 import Linear.V4
 import Linear.Vector
-import System.Random
+import System.Random (Random(..))
 
 -- | An affine space is roughly a vector space in which we have
 -- forgotten or at least pretend to have forgotten the origin.

--- a/src/Linear/Plucker.hs
+++ b/src/Linear/Plucker.hs
@@ -107,7 +107,7 @@ import Linear.V2
 import Linear.V3
 import Linear.V4
 import Linear.Vector
-import System.Random
+import System.Random (Random(..))
 
 -- | Plücker coordinates for lines in a 3-dimensional space.
 data Plucker a = Plucker !a !a !a !a !a !a deriving (Eq,Ord,Show,Read

--- a/src/Linear/Quaternion.hs
+++ b/src/Linear/Quaternion.hs
@@ -117,7 +117,7 @@ import Linear.V3
 import Linear.V4
 import Linear.Vector
 import Prelude hiding (any)
-import System.Random
+import System.Random (Random(..))
 
 -- | Quaternions
 data Quaternion a = Quaternion !a {-# UNPACK #-}!(V3 a)

--- a/src/Linear/V.hs
+++ b/src/Linear/V.hs
@@ -129,7 +129,7 @@ import Prelude as P
 #if !(MIN_VERSION_base(4,11,0))
 import Data.Semigroup
 #endif
-import System.Random
+import System.Random (Random(..))
 
 class Dim n where
   reflectDim :: p n -> Int

--- a/src/Linear/V0.hs
+++ b/src/Linear/V0.hs
@@ -96,7 +96,7 @@ import Linear.Vector
 #if __GLASGOW_HASKELL__ >= 707
 import Linear.V
 #endif
-import System.Random
+import System.Random (Random(..))
 import Prelude hiding (sum)
 
 -- $setup

--- a/src/Linear/V1.hs
+++ b/src/Linear/V1.hs
@@ -95,7 +95,7 @@ import Linear.Metric
 import Linear.Epsilon
 import Linear.Vector
 import Prelude hiding (sum)
-import System.Random
+import System.Random (Random(..))
 #if !(MIN_VERSION_base(4,11,0))
 import Data.Semigroup
 #endif

--- a/src/Linear/V2.hs
+++ b/src/Linear/V2.hs
@@ -106,7 +106,7 @@ import Linear.V
 import Linear.Vector
 import Linear.V1 (R1(..),ex)
 import Prelude hiding (sum)
-import System.Random
+import System.Random (Random(..))
 
 -- $setup
 -- >>> import Control.Applicative

--- a/src/Linear/V3.hs
+++ b/src/Linear/V3.hs
@@ -103,7 +103,7 @@ import Linear.V
 #endif
 import Linear.V2
 import Linear.Vector
-import System.Random
+import System.Random (Random(..))
 
 -- $setup
 -- >>> import Control.Lens hiding (index)

--- a/src/Linear/V4.hs
+++ b/src/Linear/V4.hs
@@ -110,7 +110,7 @@ import Linear.V
 import Linear.V2
 import Linear.V3
 import Linear.Vector
-import System.Random
+import System.Random (Random(..))
 
 -- $setup
 -- >>> import Control.Lens hiding (index)


### PR DESCRIPTION
In `random-1.2.1`, the `System.Random` module now exports a `Finite` class, which clashes with `linear`'s own `Finite` class. The fix is simple: use explicit imports from `System.Random`.

Fixes #166.