### PR TITLE
 Depend on semigroups only on GHC < 8.0

### DIFF
--- a/linear.cabal
+++ b/linear.cabal
@@ -62,7 +62,6 @@ library
     lens                 >= 4.15.2 && < 6,
     random               >= 1.0   && < 1.3,
     reflection           >= 2     && < 3,
-    semigroups           >= 0.9   && < 1,
     semigroupoids        >= 5.2.1 && < 6,
     tagged               >= 0.8.6 && < 1,
     transformers         >= 0.5   && < 0.7,
@@ -70,6 +69,9 @@ library
     unordered-containers >= 0.2.3 && < 0.3,
     vector               >= 0.12.1.2 && < 0.14,
     void                 >= 0.6   && < 1
+    
+  if impl(ghc < 8.0)
+    build-depends: semigroups >= 0.9 && < 1
 
   if flag(template-haskell) && impl(ghc)
     build-depends: template-haskell >= 2.11.1.0 && < 3.0


### PR DESCRIPTION
They are not needed on newer GHC.