### PR TITLE
Add a property based test suite

### DIFF
--- a/linear.cabal
+++ b/linear.cabal
@@ -127,6 +127,7 @@ test-suite test
   type:           exitcode-stdio-1.0
   main-is:        Test.hs
   other-modules:  Prop.Quaternion
+                  Prop.Matrix
                   Prop.Metric
                   Prop.V0
                   Prop.V1
@@ -151,6 +152,7 @@ test-suite test
     linear,
     QuickCheck >= 2.5,
     reflection,
-    vector
+    vector,
+    distributive
   default-language: Haskell2010
 

--- a/linear.cabal
+++ b/linear.cabal
@@ -127,7 +127,13 @@ test-suite test
   type:           exitcode-stdio-1.0
   main-is:        Test.hs
   other-modules:  Prop.Quaternion
+                  Prop.V0
+                  Prop.V1
+                  Prop.V2
                   Prop.V3
+                  Prop.V4
+                  Prop.V
+                  Prop.Vector
                   Unit.Binary
                   Unit.Plucker
                   Unit.V

--- a/linear.cabal
+++ b/linear.cabal
@@ -127,6 +127,7 @@ test-suite test
   type:           exitcode-stdio-1.0
   main-is:        Test.hs
   other-modules:  Prop.Quaternion
+                  Prop.Affine
                   Prop.Matrix
                   Prop.Metric
                   Prop.V0

--- a/linear.cabal
+++ b/linear.cabal
@@ -127,6 +127,7 @@ test-suite test
   type:           exitcode-stdio-1.0
   main-is:        Test.hs
   other-modules:  Prop.Quaternion
+                  Prop.Metric
                   Prop.V0
                   Prop.V1
                   Prop.V2

--- a/tests/Prop/Affine.hs
+++ b/tests/Prop/Affine.hs
@@ -1,0 +1,23 @@
+module Prop.Affine (tests) where
+
+import Linear.Affine (Affine (..))
+import Linear.V3 (V3)
+import Prop.V3 ()
+import Test.Tasty (TestTree)
+import Test.Tasty.QuickCheck (testProperty)
+
+prop_1 :: V3 Rational -> V3 Rational -> Bool
+prop_1 a b = a .+^ (b .-. a) == b
+
+prop_2 :: V3 Rational -> V3 Rational -> V3 Rational -> Bool
+prop_2 a u v = (a .+^ u) .+^ v == a .+^ (u .+^ v)
+
+prop_3 :: V3 Rational -> V3 Rational -> V3 Rational -> Bool
+prop_3 a b v = (a .-. b) .+^ v == (a .+^ v) .-. b
+
+tests :: [TestTree]
+tests =
+  [ testProperty "a .+^ (b .-. a) == b" prop_1
+  , testProperty "(a .+^ u) .+^ v == a .+^ (u .+^ v) " prop_2
+  , testProperty "(a .-. b) .+^ v == (a .+^ v) .-. b " prop_3
+  ]

--- a/tests/Prop/Matrix.hs
+++ b/tests/Prop/Matrix.hs
@@ -1,0 +1,278 @@
+{-# LANGUAGE CPP #-}
+{-# LANGUAGE DataKinds #-}
+{-# LANGUAGE TypeApplications #-}
+
+module Prop.Matrix (tests) where
+
+import Linear.Matrix (
+  Trace (trace),
+  det22, inv22,
+  det33, inv33,
+  det44, inv44,
+  identity,
+  transpose,
+  (!!*),
+  (!*!),
+  (!+!),
+  (*!!),
+ )
+import Linear.V2 (V2)
+import Linear.V3 (V3)
+import Linear.V4 (V4)
+import Linear.V (V)
+import Linear.Vector (Additive)
+import Prop.V2 ()
+import Prop.V3 ()
+import Prop.V4 ()
+import Prop.V (prop1_V, prop2_V, prop3_V)
+import Test.QuickCheck (Property, (.&&.), (==>))
+import Test.Tasty (TestTree, testGroup)
+import Test.Tasty.QuickCheck (testProperty)
+
+import Data.Distributive (Distributive)
+
+#define SQUAREMATRIX(testname) \
+  testname @V2 @Rational .&&. \
+  testname @V3 @Rational .&&. \
+  testname @V4 @Rational
+
+#define ALLMATRIX(testname) \
+  testname @V2 @V2 @Rational .&&. \
+  testname @V2 @V3 @Rational .&&. \
+  testname @V2 @V4 @Rational .&&. \
+  testname @V3 @V2 @Rational .&&. \
+  testname @V3 @V3 @Rational .&&. \
+  testname @V3 @V3 @Rational .&&. \
+  testname @V4 @V2 @Rational .&&. \
+  testname @V4 @V3 @Rational .&&. \
+  testname @V4 @V4 @Rational .&&. \
+  testname @V4 @(V 7) @Rational .&&. \
+  testname @(V 10) @(V 6) @Rational .&&. \
+  testname @(V 20) @(V 15) @Rational
+
+#define VMATRIX1(testname) \
+  prop1_V @(V2 Rational) testname .&&. \
+  prop1_V @(V3 Rational) testname .&&. \
+  prop1_V @(V4 Rational) testname .&&. \
+  prop1_V @(V 15 Rational) testname
+
+#define VMATRIX2(testname) \
+  prop2_V @(V2 Rational) testname .&&. \
+  prop2_V @(V3 Rational) testname .&&. \
+  prop2_V @(V4 Rational) testname .&&. \
+  prop2_V @(V 10 Rational) testname
+
+#define VMATRIX3(testname) \
+  prop3_V @(V2 Rational) testname .&&. \
+  prop3_V @(V3 Rational) testname .&&. \
+  prop3_V @(V4 Rational) testname .&&. \
+  prop3_V @(V 8 Rational) testname
+
+class SquareMatrix m where
+  det :: Num a => m (m a) -> a
+  inv :: Fractional a => m (m a) -> m (m a)
+
+instance SquareMatrix V2 where
+  det = det22
+  inv = inv22
+
+instance SquareMatrix V3 where
+  det = det33
+  inv = inv33
+
+instance SquareMatrix V4 where
+  det = det44
+  inv = inv44
+
+-- Properties of general matrices
+prop_addCommut :: Property
+prop_addCommut = ALLMATRIX (prop) .&&. VMATRIX2 (prop)
+ where
+  prop :: (Eq (m (n a)), Additive m, Additive n, Num a) => m (n a) -> m (n a) -> Bool
+  prop a b = (a !+! b) == (b !+! a)
+
+prop_addAssoc :: Property
+prop_addAssoc = ALLMATRIX (prop) .&&. VMATRIX3 (prop)
+ where
+  prop :: (Eq (m (n a)), Additive m, Additive n, Num a) => m (n a) -> m (n a) -> m (n a) -> Bool
+  prop a b c = ((a !+! b) !+! c) == (a !+! (b !+! c))
+
+prop_distOfScalar :: Property
+prop_distOfScalar = ALLMATRIX (prop) .&&. VMATRIX2 (prop)
+ where
+  prop :: (Eq (m (n a)), Additive m, Additive n, Foldable m, Num a)
+    => m (n a) -> m (n a) -> a -> Bool
+  prop b c a = a *!! (b !+! c) == ((a *!! b) !+! (a *!! c))
+
+prop_LRScalar :: Property
+prop_LRScalar = ALLMATRIX (prop) .&&. VMATRIX1 (prop)
+ where
+  prop :: (Functor m, Functor n, Num a, Eq (m (n a))) => m (n a) -> a -> Bool
+  prop m a = m !!* a == a *!! m
+
+-- Transpose properties
+prop_transpose :: Property
+prop_transpose = ALLMATRIX (prop) .&&. VMATRIX1 (prop)
+ where
+  prop :: (Eq (m (n a)), Distributive m, Distributive n) => m (n a) -> Bool
+  prop a = transpose (transpose a) == a
+
+prop_transposeDistAdd :: Property
+prop_transposeDistAdd = ALLMATRIX (prop) .&&. VMATRIX2 (prop)
+ where
+  prop :: ( Eq (n (m a)), Additive m, Distributive m, Distributive n,
+    Additive n , Num a)
+    => m (n a) -> m (n a) -> Bool
+  prop a b = transpose (a !+! b) == (transpose a !+! transpose b)
+
+prop_transposeDistMul :: Property
+prop_transposeDistMul = ALLMATRIX (prop)
+ where
+  prop :: ( Additive m, Foldable m, Distributive m, Distributive n, Foldable n
+    , Additive n, Num a, Eq (m (m a)))
+    => m (n a) -> n (m a) -> Bool
+  prop a b = transpose (a !*! b) == (transpose b !*! transpose a)
+
+-- Identity properties
+prop_identityNeutralL :: Property
+prop_identityNeutralL = ALLMATRIX (prop) .&&. VMATRIX1 (prop)
+ where
+  prop :: ( Eq (m (n a)), Functor m, Additive n, Traversable n, Applicative n, Num a)
+    => m (n a) -> Bool
+  prop a = a !*! identity == a
+
+prop_identityNeutralR :: Property
+prop_identityNeutralR = ALLMATRIX (prop) .&&. VMATRIX1 (prop)
+ where
+  prop :: ( Eq (m (n a)), Additive m, Foldable m, Traversable m,
+    Applicative m, Additive n, Num a)
+    => m (n a) -> Bool
+  prop a = identity !*! a == a
+
+-- Properties of square matrices
+prop_mulAssoc :: Property
+prop_mulAssoc = SQUAREMATRIX (prop)
+ where
+  prop :: (Eq (m (m a)), Additive m, Foldable m, Num a)
+    => m (m a) -> m (m a) -> m (m a) -> Bool
+  prop a b c = ((a !*! b) !*! c) == (a !*! (b !*! c))
+
+prop_distOfMatrix :: Property
+prop_distOfMatrix = SQUAREMATRIX (prop)
+ where
+  prop :: (Eq (m (m a)), Additive m, Foldable m, Num a)
+    => m (m a) -> m (m a) -> m (m a) -> Bool
+  prop a b c = (a !*! (b !+! c)) == ((a !*! b) !+! (a !*! c))
+
+-- Inverse properties
+prop_inv :: Property
+prop_inv = SQUAREMATRIX (prop)
+ where
+  prop :: (Additive m, Fractional a, SquareMatrix m, Eq (m (m a)), Eq a)
+    => m (m a) -> Property
+  prop a = (det a /= 0) ==> inv (inv a) == a
+
+prop_invIdent :: Property
+prop_invIdent = SQUAREMATRIX (prop)
+ where
+  prop :: ( Additive m, Foldable m, Traversable m, Applicative m, Fractional a
+    , SquareMatrix m, Eq (m (m a)), Eq a )
+    => m (m a) -> Property
+  prop a = det a /= 0 ==> a !*! inv a == identity
+
+prop_invMult :: Property
+prop_invMult = SQUAREMATRIX (prop)
+ where
+  prop :: ( Additive m, Foldable m, Fractional a, SquareMatrix m, Eq a, Eq (m (m a)))
+    => m (m a) -> m (m a) -> Property
+  prop a b = det a /= 0 && det b /= 0 ==> (inv (a !*! b) == (inv b !*! inv a))
+
+-- Determinant properties
+prop_detTranspose :: Property
+prop_detTranspose = SQUAREMATRIX (prop)
+ where
+  prop :: (Additive m, Distributive m, Fractional a, SquareMatrix m, Eq a)
+    => m (m a) -> Bool
+  prop a = det (transpose a) == det a
+
+prop_detProd :: Property
+prop_detProd = SQUAREMATRIX (prop)
+ where
+  prop :: (Additive m, Foldable m, Fractional a, SquareMatrix m, Eq a)
+    => m (m a) -> m (m a) -> Bool
+  prop a b = det (a !*! b) == det a * det b
+
+prop_detScalarPow :: Property
+prop_detScalarPow = SQUAREMATRIX (prop)
+ where
+  prop :: (Additive m, Fractional a, Foldable m, SquareMatrix m, Eq a)
+    => m (m a) -> a -> Bool
+  prop a c = det (c *!! a) == (c ^ n) * det a
+   where
+    n = length a
+
+-- Trace properties
+prop_traceLinear :: Property
+prop_traceLinear = SQUAREMATRIX (prop) .&&. prop @(V 10) @Rational
+ where
+  prop :: (Trace m, Additive m, Num a, Eq a) => m (m a) -> m (m a) -> Bool
+  prop a b = trace (a !+! b) == (trace a + trace b)
+
+prop_traceTranspose :: Property
+prop_traceTranspose = SQUAREMATRIX (prop) .&&. prop @(V 10) @Rational
+ where
+  prop :: (Trace m, Distributive m, Num a, Eq a) => m (m a) -> Bool
+  prop a = trace a == trace (transpose a)
+
+prop_traceSwap :: Property
+prop_traceSwap = SQUAREMATRIX (prop) .&&. prop @(V 15) @Rational
+ where
+  prop :: (Foldable m, Trace m, Additive m, Eq a, Num a)
+    => m (m a) -> m (m a) -> Bool
+  prop a b = trace (a !*! b) == trace (b !*! a)
+
+tests :: [TestTree]
+tests =
+  [ testGroup
+      "General Matrix Properties"
+      [ testGroup
+          "Basic Properties"
+          [ testProperty "commutativity of !+!" prop_addCommut
+          , testProperty "associativity of !+!" prop_addAssoc
+          , testProperty "distributivity of scalar mult" prop_distOfScalar
+          , testProperty "left and right scalar product are equal" prop_LRScalar
+          ]
+      , testGroup
+          "Transpose Properties"
+          [ testProperty "(A^T)^T == A" prop_transpose
+          , testProperty "(A !+! B)^T == (A^T !+! B^T)" prop_transposeDistAdd
+          , testProperty "(AB)^T == (B^T !*! A^T)" prop_transposeDistMul
+          ]
+      , testGroup
+          "Identity Properties"
+          [ testProperty "identity is neutral under !*!" prop_identityNeutralR
+          , testProperty "identity is neutral under !*!" prop_identityNeutralL
+          ]
+      ]
+  , testGroup
+      "Square matrix properties"
+      [ testProperty "associativity of !*!" prop_mulAssoc
+      , testProperty "distributivity of !*!" prop_distOfMatrix
+      , testGroup "Inverse properties"
+        [ testProperty "inv (inv a) == a" prop_inv
+        , testProperty "a !*! inv a == I" prop_invIdent
+        , testProperty "(AB)^-1 == B^-1 * A^-1" prop_invMult
+        ]
+      , testGroup "Determinant properties"
+        [ testProperty "det A^T = det A" prop_detTranspose
+        , testProperty "det (AB) = det A * det B" prop_detProd
+        , testProperty "det (cA) = c^2 * det A" prop_detScalarPow
+        ]
+      , testGroup
+        "Trace Properties"
+        [ testProperty "trace (A+B) == trace A + trace B" prop_traceLinear
+        , testProperty "trace A == trace (A^T)" prop_traceTranspose
+        , testProperty "trace (AB) == trace (BA)" prop_traceSwap
+        ]
+      ]
+  ]

--- a/tests/Prop/Metric.hs
+++ b/tests/Prop/Metric.hs
@@ -1,0 +1,79 @@
+{-# LANGUAGE CPP #-}
+{-# LANGUAGE TypeApplications #-}
+
+module Prop.Metric (tests) where
+
+import Linear.Metric (Metric, dot, norm)
+import Linear.V1 (V1 (..))
+import Linear.V2 (V2 (..))
+import Linear.V3 (V3 (..))
+import Linear.V4 (V4 (..))
+import Linear.Vector ((^+^), (^-^))
+import Prop.V1 ()
+import Prop.V2 ()
+import Prop.V3 ()
+import Prop.V4 ()
+import Prop.V (prop2_V, prop3_V)
+import Test.QuickCheck (Property, (.&&.))
+import Test.Tasty (TestTree)
+import Test.Tasty.QuickCheck (testProperty)
+
+#define ALLVECTORS(testname) \
+  prop @V1 @Rational .&&. \
+  prop @V2 @Rational .&&. \
+  prop @V3 @Rational .&&. \
+  prop @V4 @Rational
+
+prop_dotCommut :: Property
+prop_dotCommut = ALLVECTORS (prop) .&&. prop2_V @Rational prop
+ where
+  prop :: (Metric v, Num a, Eq a) => v a -> v a -> Bool
+  prop a b = a `dot` b == b `dot` a
+
+prop_dotDist :: Property
+prop_dotDist = ALLVECTORS (prop) .&&. prop3_V @Rational prop
+ where
+  prop :: (Metric v, Num a, Eq a) => v a -> v a -> v a -> Bool
+  prop a b c = (a ^+^ b) `dot` c == (a `dot` c) + (b `dot` c)
+
+prop_CSIneq :: Property
+prop_CSIneq =
+  prop @V1 @Double
+    .&&. prop @V2 @Double
+    .&&. prop @V3 @Double
+    .&&. prop @V4 @Double
+    .&&. prop2_V @Double prop
+ where
+  prop :: (Metric v, Floating a, Ord a) => v a -> v a -> Bool
+  prop a b = a `dot` b <= norm a * norm b + 1e-12
+
+prop_triangleIneq :: Property
+prop_triangleIneq =
+  prop @V1 @Double
+    .&&. prop @V2 @Double
+    .&&. prop @V3 @Double
+    .&&. prop @V4 @Double
+    .&&. prop2_V @Double prop
+ where
+  prop :: (Metric v, Floating a, Ord a) => v a -> v a -> Bool
+  prop a b = norm (a ^+^ b) <= norm a + norm b + 1e-12
+
+prop_invTriangleIneq :: Property
+prop_invTriangleIneq =
+  prop @V1 @Double
+    .&&. prop @V2 @Double
+    .&&. prop @V3 @Double
+    .&&. prop @V4 @Double
+    .&&. prop2_V @Double prop
+ where
+  prop :: (Metric v, Floating a, Ord a) => v a -> v a -> Bool
+  prop a b = norm (a ^-^ b) + 1e-12 >= norm a - norm b
+
+tests :: [TestTree]
+tests =
+  [ testProperty "commutativity of scalar product" prop_dotCommut
+  , testProperty "distributivity of scalar product over addition" prop_dotDist
+  , testProperty "Cauchy–Schwarz inequality" prop_CSIneq
+  , testProperty "triangle Inequality" prop_triangleIneq
+  , testProperty "inverse Triangle Inequality" prop_invTriangleIneq
+  ]

--- a/tests/Prop/Quaternion.hs
+++ b/tests/Prop/Quaternion.hs
@@ -1,16 +1,20 @@
 {-# OPTIONS_GHC -Wno-orphans #-}
+
 module Prop.Quaternion (tests) where
 
-import Linear.Quaternion (Quaternion(..))
+import Linear.Conjugate
 import Linear.Epsilon (nearZero)
+import Linear.Metric (signorm)
+import Linear.Quaternion (Quaternion (..), rotate)
+import Linear.V3 (V3 (..))
 import Linear.Vector (lerp)
-import Test.QuickCheck (Arbitrary(..))
+import Test.QuickCheck (Arbitrary (..), Property, (==>))
 import Test.Tasty (TestTree, testGroup)
 import Test.Tasty.QuickCheck (testProperty)
 
 import Prop.V3 ()
 
-instance Arbitrary a => Arbitrary (Quaternion a) where
+instance (Arbitrary a) => Arbitrary (Quaternion a) where
   arbitrary = Quaternion <$> arbitrary <*> arbitrary
 
 prop_lerp0 :: Quaternion Double -> Quaternion Double -> Bool
@@ -19,10 +23,17 @@ prop_lerp0 a b = nearZero (lerp 0 a b - a)
 prop_lerp1 :: Quaternion Double -> Quaternion Double -> Bool
 prop_lerp1 a b = nearZero (lerp 1 a b - b)
 
+prop_rotateInverse :: Quaternion Double -> V3 Double -> Property
+prop_rotateInverse q v = q /= 0 ==> nearZero (rotate (conjugate qn) (rotate qn v) - v)
+ where
+  qn = signorm q
+
 tests :: [TestTree]
 tests =
-  [ testGroup "lerp"
-    [ testProperty "lerp 0 a b == a" prop_lerp0
-    , testProperty "lerp 1 a b == b" prop_lerp1
-    ]
+  [ testGroup
+      "lerp"
+      [ testProperty "lerp 0 a b == a" prop_lerp0
+      , testProperty "lerp 1 a b == b" prop_lerp1
+      ]
+  , testProperty "conjugate quaternion creates inverse rotation" prop_rotateInverse
   ]

--- a/tests/Prop/V.hs
+++ b/tests/Prop/V.hs
@@ -1,0 +1,52 @@
+{-# LANGUAGE CPP #-}
+{-# LANGUAGE DataKinds #-}
+{-# LANGUAGE PolyKinds #-}
+{-# LANGUAGE RankNTypes #-}
+{-# LANGUAGE ScopedTypeVariables #-}
+{-# LANGUAGE TypeApplications #-}
+{-# OPTIONS_GHC -Wno-orphans #-}
+
+module Prop.V (prop1_V, prop2_V, prop3_V) where
+
+import Data.Proxy (Proxy (..))
+import qualified Data.Vector as V
+import Linear.V (Dim (..), V (..))
+import Test.QuickCheck (Arbitrary (..), Property, Testable, getNonNegative, property, vector)
+
+import GHC.TypeLits (Nat, KnownNat, SomeNat (..), someNatVal)
+
+instance (Dim n, Arbitrary a) => Arbitrary (V n a) where
+  arbitrary = do
+    l <- vector $ reflectDim $ Proxy @n
+    pure $ V $ V.fromList l
+
+instance Arbitrary SomeNat where
+  arbitrary = do
+    nat <- getNonNegative <$> arbitrary
+    case someNatVal nat of
+      Just sn -> pure sn
+      Nothing -> error "impossible: `nat` should be non-negative"
+
+prop1_V ::
+  forall a prop.
+  (Arbitrary a, Show a, Testable prop) =>
+  (forall (n :: Nat). KnownNat n => V n a -> prop) ->
+  SomeNat ->
+  Property
+prop1_V f (SomeNat (Proxy :: Proxy n)) = property $ f @n
+
+prop2_V ::
+  forall a prop.
+  (Arbitrary a, Show a, Testable prop) =>
+  (forall (n :: Nat). KnownNat n => V n a -> V n a -> prop) ->
+  SomeNat ->
+  Property
+prop2_V f (SomeNat (Proxy :: Proxy n)) = property $ f @n
+
+prop3_V ::
+  forall a prop.
+  (Arbitrary a, Show a, Testable prop) =>
+  (forall (n :: Nat). KnownNat n => V n a -> V n a -> V n a -> prop) ->
+  SomeNat ->
+  Property
+prop3_V f (SomeNat (Proxy :: Proxy n)) = property $ f @n

--- a/tests/Prop/V0.hs
+++ b/tests/Prop/V0.hs
@@ -1,0 +1,9 @@
+{-# OPTIONS_GHC -Wno-orphans #-}
+
+module Prop.V0 () where
+
+import Linear.V0 (V0 (..))
+import Test.QuickCheck (Arbitrary (..))
+
+instance Arbitrary (V0 a) where
+  arbitrary = return V0

--- a/tests/Prop/V1.hs
+++ b/tests/Prop/V1.hs
@@ -1,0 +1,9 @@
+{-# OPTIONS_GHC -Wno-orphans #-}
+
+module Prop.V1 () where
+
+import Linear.V1 (V1 (..))
+import Test.QuickCheck (Arbitrary (..))
+
+instance (Arbitrary a) => Arbitrary (V1 a) where
+  arbitrary = V1 <$> arbitrary

--- a/tests/Prop/V2.hs
+++ b/tests/Prop/V2.hs
@@ -1,0 +1,25 @@
+{-# OPTIONS_GHC -Wno-orphans #-}
+
+module Prop.V2 (tests) where
+
+import Linear.V2 (V2 (..), perp, angle, unangle)
+import Test.Tasty (TestTree)
+import Test.Tasty.QuickCheck (testProperty)
+import Test.QuickCheck (Arbitrary (..), forAll, choose)
+
+instance (Arbitrary a) => Arbitrary (V2 a) where
+  arbitrary = V2 <$> arbitrary <*> arbitrary
+
+prop_quadPerp :: V2 Rational -> Bool
+prop_quadPerp a = (perp . perp . perp . perp) a == a
+
+-- Fairly large margin of error for this one,
+-- but 1e-7 was the smallest to consistently pass.
+prop_unangleInverse :: Double -> Bool
+prop_unangleInverse a = ((1e-7 >) . abs) ((unangle . angle) a - a)
+
+tests :: [TestTree]
+tests =
+  [ testProperty "4 perpendicular is unchanged" prop_quadPerp
+  , testProperty "unangle is inverse of angle" $ forAll (choose (-pi / 2 , 3/2 * pi - 1e-12 )) prop_unangleInverse
+  ]

--- a/tests/Prop/V3.hs
+++ b/tests/Prop/V3.hs
@@ -1,8 +1,42 @@
 {-# OPTIONS_GHC -Wno-orphans #-}
-module Prop.V3 () where
 
-import Linear.V3 (V3(..))
-import Test.QuickCheck (Arbitrary(..))
+module Prop.V3 (tests) where
 
-instance Arbitrary a => Arbitrary (V3 a) where
+import Linear.Metric (dot)
+import Linear.V3 (V3 (..), cross, triple)
+import Linear.Vector (zero, (*^), (^-^), (^+^))
+import Test.QuickCheck (Arbitrary (..))
+import Test.Tasty (TestTree)
+import Test.Tasty.QuickCheck (testProperty)
+
+instance (Arbitrary a) => Arbitrary (V3 a) where
   arbitrary = V3 <$> arbitrary <*> arbitrary <*> arbitrary
+
+prop_crossInv :: V3 Rational -> V3 Rational -> Bool
+prop_crossInv a b = a `cross` b == -(b `cross` a)
+
+prop_selfCross :: V3 Rational -> Bool
+prop_selfCross a = a `cross` a == zero
+
+prop_distCross :: V3 Rational -> V3 Rational -> V3 Rational -> Bool
+prop_distCross a b c = (a ^+^ b) `cross` c == (a `cross` c) ^+^ (b `cross` c)
+
+prop_vectorTripleprod :: V3 Rational -> V3 Rational -> V3 Rational -> Bool
+prop_vectorTripleprod a b c =
+  (a `cross` (b `cross` c)) == ((a `dot` c) *^ b) ^-^ ((a `dot` b) *^ c)
+
+prop_tripleCircular :: V3 Rational -> V3 Rational -> V3 Rational -> Bool
+prop_tripleCircular a b c = triple a b c == triple b c a
+
+prop_tripleSwap :: V3 Rational -> V3 Rational -> V3 Rational -> Bool
+prop_tripleSwap a b c = triple a b c == - triple a c b
+
+tests :: [TestTree]
+tests =
+  [ testProperty "a x b == - (b x a)" prop_crossInv
+  , testProperty "a x a == 0" prop_selfCross
+  , testProperty "(a + b) x c == a x c + b x c" prop_distCross
+  , testProperty "vector triple product" prop_vectorTripleprod
+  , testProperty "triple a b c = triple b c a" prop_tripleCircular
+  , testProperty "triple a b c = -triple a c b" prop_tripleSwap
+  ]

--- a/tests/Prop/V4.hs
+++ b/tests/Prop/V4.hs
@@ -1,0 +1,9 @@
+{-# OPTIONS_GHC -Wno-orphans #-}
+
+module Prop.V4 () where
+
+import Linear.V4 (V4 (..))
+import Test.QuickCheck (Arbitrary (..))
+
+instance (Arbitrary a) => Arbitrary (V4 a) where
+  arbitrary = V4 <$> arbitrary <*> arbitrary <*> arbitrary <*> arbitrary

--- a/tests/Prop/Vector.hs
+++ b/tests/Prop/Vector.hs
@@ -1,0 +1,73 @@
+{-# LANGUAGE CPP #-}
+{-# LANGUAGE TypeApplications #-}
+
+module Prop.Vector (tests) where
+
+import Linear.V0 (V0)
+import Linear.V1 (V1)
+import Linear.V2 (V2)
+import Linear.V3 (V3)
+import Linear.V4 (V4)
+import Linear.Vector (Additive (..), negated, zero, (*^), (^*))
+import Prop.V0 ()
+import Prop.V1 ()
+import Prop.V2 ()
+import Prop.V3 ()
+import Prop.V4 ()
+import Prop.V (prop1_V, prop2_V, prop3_V)
+import Test.QuickCheck (Property, (.&&.))
+import Test.Tasty (TestTree)
+import Test.Tasty.QuickCheck (testProperty)
+
+#define ALLVECTORS(testname) \
+  testname @V0 @Rational .&&. \
+  testname @V1 @Rational .&&. \
+  testname @V2 @Rational .&&. \
+  testname @V3 @Rational .&&. \
+  testname @V4 @Rational
+
+prop_addAssoc :: Property
+prop_addAssoc = ALLVECTORS (prop) .&&. prop3_V @Rational prop
+ where
+  prop :: (Eq (v a), Additive v, Num a) => v a -> v a -> v a -> Bool
+  prop a b c = ((a ^+^ b) ^+^ c) == (a ^+^ (b ^+^ c))
+
+prop_addCommut :: Property
+prop_addCommut = ALLVECTORS (prop) .&&. prop2_V @Rational prop
+ where
+  prop :: (Eq (v a), Additive v, Num a) => v a -> v a -> Bool
+  prop a b = (a ^+^ b) == (b ^+^ a)
+
+prop_LRScalarProduct :: Property
+prop_LRScalarProduct = ALLVECTORS (prop) .&&. prop1_V @Rational prop
+ where
+  prop :: (Eq (v a), Functor v, Num a) => v a -> a -> Bool
+  prop v a = v ^* a == a *^ v
+
+prop_distScalarR :: Property
+prop_distScalarR = ALLVECTORS (prop) .&&. prop2_V @Rational prop
+ where
+  prop :: (Eq (v a), Additive v, Num a) => v a -> v a -> a -> Bool
+  prop a b c = (a ^+^ b) ^* c == (a ^* c) ^+^ (b ^* c)
+
+prop_distScalarL :: Property
+prop_distScalarL = ALLVECTORS (prop) .&&. prop2_V @Rational prop
+ where
+  prop :: (Eq (v a), Additive v, Num a) => v a -> v a -> a -> Bool
+  prop a b c = c *^ (a ^+^ b) == (c *^ a) ^+^ (c *^ b)
+
+prop_negateVector :: Property
+prop_negateVector = ALLVECTORS (prop) .&&. prop1_V @Rational prop
+ where
+  prop :: (Eq (v a), Additive v, Num a) => v a -> Bool
+  prop a = (a ^+^ negated a) == zero
+
+tests :: [TestTree]
+tests =
+  [ testProperty "left and right scalar product are equal" prop_LRScalarProduct
+  , testProperty "right scalar mult is distributive over vector addition" prop_distScalarR
+  , testProperty "left scalar mult is distributive over vector addition" prop_distScalarL
+  , testProperty "negation is inverse under ^+^" prop_negateVector
+  , testProperty "associativity of ^+^" prop_addAssoc
+  , testProperty "commutativity of ^+^" prop_addCommut
+  ]

--- a/tests/Test.hs
+++ b/tests/Test.hs
@@ -9,6 +9,7 @@ import qualified Prop.Metric
 import qualified Prop.Vector
 import qualified Prop.V2
 import qualified Prop.V3
+import qualified Prop.Affine
 import qualified Unit.Binary
 import qualified Unit.Plucker
 import qualified Unit.V
@@ -22,6 +23,7 @@ tests =
     , testGroup "Vector" Prop.Vector.tests
     , testGroup "V2" Prop.V2.tests
     , testGroup "V3" Prop.V3.tests
+    , testGroup "Affine" Prop.Affine.tests
     ]
   , testGroup "Unit tests"
     [ testGroup "Binary" Unit.Binary.tests

--- a/tests/Test.hs
+++ b/tests/Test.hs
@@ -4,6 +4,7 @@ module Main (main) where
 import Test.Tasty (defaultMain, testGroup, TestTree)
 
 import qualified Prop.Quaternion
+import qualified Prop.Metric
 import qualified Prop.Vector
 import qualified Prop.V2
 import qualified Prop.V3
@@ -15,6 +16,7 @@ tests :: [TestTree]
 tests =
   [ testGroup "Property tests"
     [ testGroup "Quaternion" Prop.Quaternion.tests
+    , testGroup "Metric" Prop.Metric.tests
     , testGroup "Vector" Prop.Vector.tests
     , testGroup "V2" Prop.V2.tests
     , testGroup "V3" Prop.V3.tests

--- a/tests/Test.hs
+++ b/tests/Test.hs
@@ -4,6 +4,7 @@ module Main (main) where
 import Test.Tasty (defaultMain, testGroup, TestTree)
 
 import qualified Prop.Quaternion
+import qualified Prop.Matrix
 import qualified Prop.Metric
 import qualified Prop.Vector
 import qualified Prop.V2
@@ -16,6 +17,7 @@ tests :: [TestTree]
 tests =
   [ testGroup "Property tests"
     [ testGroup "Quaternion" Prop.Quaternion.tests
+    , testGroup "Matrix" Prop.Matrix.tests
     , testGroup "Metric" Prop.Metric.tests
     , testGroup "Vector" Prop.Vector.tests
     , testGroup "V2" Prop.V2.tests

--- a/tests/Test.hs
+++ b/tests/Test.hs
@@ -4,6 +4,9 @@ module Main (main) where
 import Test.Tasty (defaultMain, testGroup, TestTree)
 
 import qualified Prop.Quaternion
+import qualified Prop.Vector
+import qualified Prop.V2
+import qualified Prop.V3
 import qualified Unit.Binary
 import qualified Unit.Plucker
 import qualified Unit.V
@@ -12,6 +15,9 @@ tests :: [TestTree]
 tests =
   [ testGroup "Property tests"
     [ testGroup "Quaternion" Prop.Quaternion.tests
+    , testGroup "Vector" Prop.Vector.tests
+    , testGroup "V2" Prop.V2.tests
+    , testGroup "V3" Prop.V3.tests
     ]
   , testGroup "Unit tests"
     [ testGroup "Binary" Unit.Binary.tests


### PR DESCRIPTION
These commits adds tests for many of the data structures and modules of the language. 

The things that needs to be mentioned the most are probably the CPP defines for testing polymorphic functions.  The only solution we found was to fully inline the code or the type checker could not solve the types for QuickCheck to function. The macros just provided a simple way to cut down on the boilerplate code. If there is a better way to do this we would love to know.

-- Axel Flordal & Anton Nordbeck